### PR TITLE
The ctype fields where incorrectly defined. 

### DIFF
--- a/opt4048_registers.py
+++ b/opt4048_registers.py
@@ -68,7 +68,7 @@ SFE_OPT4048_REGISTER_EXP_RES_CH0 = 0x00
 class opt4048_reg_exp_res_ch0_bits_t(ctypes.LittleEndianStructure):
     _fields_ = [
         ("result_msb_ch0", ctypes.c_uint16, 12),
-        ("exponent_ch0", ctypes.c_uint8, 4),
+        ("exponent_ch0", ctypes.c_uint16, 4),
     ]
 
 
@@ -105,7 +105,7 @@ SFE_OPT4048_REGISTER_EXP_RES_CH1 = 0x02
 class opt4048_reg_exp_res_ch1_bits_t(ctypes.LittleEndianStructure):
     _fields_ = [
         ("result_msb_ch1", ctypes.c_uint16, 12),
-        ("exponent_ch1", ctypes.c_uint8, 4),
+        ("exponent_ch1", ctypes.c_uint16, 4),
     ]
 
 
@@ -142,7 +142,7 @@ SFE_OPT4048_REGISTER_EXP_RES_CH2 = 0x04
 class opt4048_reg_exp_res_ch2_bits_t(ctypes.LittleEndianStructure):
     _fields_ = [
         ("result_msb_ch2", ctypes.c_uint16, 12),
-        ("exponent_ch2", ctypes.c_uint8, 4),
+        ("exponent_ch2", ctypes.c_uint16, 4),
     ]
 
 
@@ -179,7 +179,7 @@ SFE_OPT4048_REGISTER_EXP_RES_CH3 = 0x06
 class opt4048_reg_exp_res_ch3_bits_t(ctypes.LittleEndianStructure):
     _fields_ = [
         ("result_msb_ch3", ctypes.c_uint16, 12),
-        ("exponent_ch3", ctypes.c_uint8, 4),
+        ("exponent_ch3", ctypes.c_uint16, 4),
     ]
 
 
@@ -216,7 +216,7 @@ SFE_OPT4048_REGISTER_THRESH_L_EXP_RES = 0x08
 class opt4048_reg_thresh_exp_res_low_bits_t(ctypes.LittleEndianStructure):
     _fields_ = [
         ("thresh_result", ctypes.c_uint16, 12),
-        ("thresh_exp", ctypes.c_uint8, 4),
+        ("thresh_exp", ctypes.c_uint16, 4),
     ]
 
 
@@ -234,7 +234,7 @@ SFE_OPT4048_REGISTER_THRESH_H_EXP_RES = 0x09
 class opt4048_reg_thresh_exp_res_high_bits_t(ctypes.LittleEndianStructure):
     _fields_ = [
         ("thresh_result", ctypes.c_uint16, 12),
-        ("thresh_exp", ctypes.c_uint8, 4),
+        ("thresh_exp", ctypes.c_uint16, 4),
     ]
 
 
@@ -251,14 +251,14 @@ SFE_OPT4048_REGISTER_CONTROL = 0x0A
 
 class opt4048_reg_control_bits_t(ctypes.LittleEndianStructure):
     _fields_ = [
-        ("fault_count", ctypes.c_uint8, 2),
-        ("int_pol", ctypes.c_uint8, 1),
-        ("latch", ctypes.c_uint8, 1),
-        ("op_mode", ctypes.c_uint8, 2),
-        ("conversion_time", ctypes.c_uint8, 4),
-        ("range", ctypes.c_uint8, 4),
-        ("reserved", ctypes.c_uint8, 1),
-        ("qwake", ctypes.c_uint8, 1),
+        ("fault_count", ctypes.c_uint16, 2),
+        ("int_pol", ctypes.c_uint16, 1),
+        ("latch", ctypes.c_uint16, 1),
+        ("op_mode", ctypes.c_uint16, 2),
+        ("conversion_time", ctypes.c_uint16, 4),
+        ("range", ctypes.c_uint16, 4),
+        ("reserved", ctypes.c_uint16, 1),
+        ("qwake", ctypes.c_uint16, 1),
     ]
 
 
@@ -275,11 +275,11 @@ SFE_OPT4048_REGISTER_INT_CONTROL = 0x0B
 
 class opt4048_reg_int_control_bits_t(ctypes.LittleEndianStructure):
     _fields_ = [
-        ("i2c_burst", ctypes.c_uint8, 1),
-        ("reserved_two", ctypes.c_uint8, 1),
-        ("int_cfg", ctypes.c_uint8, 2),
-        ("int_dir", ctypes.c_uint8, 1),
-        ("threshold_ch_sel", ctypes.c_uint8, 2),
+        ("i2c_burst", ctypes.c_uint16, 1),
+        ("reserved_two", ctypes.c_uint16, 1),
+        ("int_cfg", ctypes.c_uint16, 2),
+        ("int_dir", ctypes.c_uint16, 1),
+        ("threshold_ch_sel", ctypes.c_uint16, 2),
         ("reserved_one", ctypes.c_uint16, 9),
     ]
 
@@ -297,10 +297,10 @@ SFE_OPT4048_REGISTER_FLAGS = 0x0C
 
 class opt4048_reg_flags_bits_t(ctypes.LittleEndianStructure):
     _fields_ = [
-        ("flag_low", ctypes.c_uint8, 1),
-        ("flag_high", ctypes.c_uint8, 1),
-        ("conv_ready_flag", ctypes.c_uint8, 1),
-        ("overload_flag", ctypes.c_uint8, 1),
+        ("flag_low", ctypes.c_uint16, 1),
+        ("flag_high", ctypes.c_uint16, 1),
+        ("conv_ready_flag", ctypes.c_uint16, 1),
+        ("overload_flag", ctypes.c_uint16, 1),
         ("reserved", ctypes.c_uint16, 12),
     ]
 
@@ -319,7 +319,7 @@ SFE_OPT4048_REGISTER_DEVICE_ID = 0x11
 class opt4048_reg_device_id_bits_t(ctypes.LittleEndianStructure):
     _fields_ = [
         ("DIDH", ctypes.c_uint16, 12),
-        ("DIDL", ctypes.c_uint8, 2),
+        ("DIDL", ctypes.c_uint16, 2),
         ("reserved", ctypes.c_uint16, 2),
     ]
 


### PR DESCRIPTION
The ctype fields where incorrectly defined in that a mix of 16 and 8 bit fields which cause the bit counter to reset to a new byte. Noticed that the exponent was not scaling the adc reading correctly.