### PR TITLE
Fix ModuleNotFoundError by adding opt4048_registers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,6 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    py_modules=["qwiic_opt4048"],
+    py_modules=["qwiic_opt4048", "opt4048_registers"],
 
 )


### PR DESCRIPTION
**Bug:**
Currently, installing via `pip` or running `setup.py install` results in a `ModuleNotFoundError` because `opt4048_registers.py` is not included in the package build.

**Fix:** (fixes #4)
I updated `setup.py` (line 98) to explicitly include `opt4048_registers` in the `py_modules` list, ensuring both `qwiic_opt4048.py` and `opt4048_registers.py` are installed to site-packages.